### PR TITLE
make sure %y%m%d is being used

### DIFF
--- a/pandas_datareader/yahoo/options.py
+++ b/pandas_datareader/yahoo/options.py
@@ -480,7 +480,7 @@ class Options(_OptionBaseReader):
         If the expiry date does not have options that expire on that day, return next expiry"""
 
         expiry_dates = self.expiry_dates
-        expiry = to_datetime(expiry)
+        expiry = to_datetime(expiry, format='%y%m%d) # or firstYear=True
         if hasattr(expiry, 'date'):
             expiry = expiry.date()
 
@@ -677,7 +677,7 @@ class Options(_OptionBaseReader):
         frame.columns = ['Strike', 'Symbol', 'Last', 'Bid', 'Ask', 'Chg', 'PctChg', 'Vol', 'Open_Int', 'IV']
         frame["Rootexp"] = frame.Symbol.str[0:-9]
         frame["Root"] = frame.Rootexp.str[0:-6]
-        frame["Expiry"] = to_datetime(frame.Rootexp.str[-6:])
+        frame["Expiry"] = to_datetime(frame.Rootexp.str[-6:], format='%y%m%d)
         # Removes dashes in equity ticker to map to option ticker.
         # Ex: BRK-B to BRKB140517C00100000
         frame["IsNonstandard"] = frame['Root'] != self.symbol.replace('-', '')


### PR DESCRIPTION
['Exipry'] dates are getting messed up on some linux installations.
Forcing %y%m%d when to_datetime() is invoked.
